### PR TITLE
password auth: Avoid mandatory password rotation

### DIFF
--- a/pages/password-authentication.md
+++ b/pages/password-authentication.md
@@ -138,5 +138,6 @@ If you need to keep the username or email private, make sure you do not leak suc
 ## Other considerations
 
 - Do not prevent users from copy-pasting passwords as it discourages users from using password managers.
+- Do not require users to change passwords periodically.
 - Ask for the current password when a user attempts to change their password.
 - [Open redirect](/open-redirect).


### PR DESCRIPTION
This aligns with NIST SP 800-63B, Microsoft 365 Password Policy Recommendations, etc, etc